### PR TITLE
Setting/#19 버튼을 클릭하면 관련 설정 메뉴가 나오도록(기능 없이) -> 데이터 구조 수정 및 이미지 불러오는 방법 변경  

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		784EB5DB2A0346C70096D427 /* EditMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5DA2A0346C70096D427 /* EditMenuView.swift */; };
 		784EB5DD2A0346E20096D427 /* BgColorGeoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5DC2A0346E20096D427 /* BgColorGeoView.swift */; };
 		784EB5DF2A0346FA0096D427 /* MultiPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5DE2A0346FA0096D427 /* MultiPreview.swift */; };
+		784EB5E12A0370E80096D427 /* EditColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5E02A0370E80096D427 /* EditColorView.swift */; };
 		78C24FD62A0242710070906B /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C24FD52A0242710070906B /* ColorExtension.swift */; };
 /* End PBXBuildFile section */
 
@@ -56,6 +57,7 @@
 		784EB5DA2A0346C70096D427 /* EditMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMenuView.swift; sourceTree = "<group>"; };
 		784EB5DC2A0346E20096D427 /* BgColorGeoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BgColorGeoView.swift; sourceTree = "<group>"; };
 		784EB5DE2A0346FA0096D427 /* MultiPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiPreview.swift; sourceTree = "<group>"; };
+		784EB5E02A0370E80096D427 /* EditColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditColorView.swift; sourceTree = "<group>"; };
 		7891C6712A02802F006B5109 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		78C24FD52A0242710070906B /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -91,12 +93,12 @@
 			isa = PBXGroup;
 			children = (
 				166972612A015A4600702B59 /* mc2_DreamLogApp.swift */,
+				166972632A015A4600702B59 /* ContentView.swift */,
 				784EB5C72A0345830096D427 /* View */,
 				784EB5C42A0345560096D427 /* Model */,
-				7891C6712A02802F006B5109 /* Info.plist */,
 				78C24FD32A0242540070906B /* Global */,
-				166972632A015A4600702B59 /* ContentView.swift */,
 				166972652A015A4800702B59 /* Assets.xcassets */,
+				7891C6712A02802F006B5109 /* Info.plist */,
 				166972672A015A4800702B59 /* Preview Content */,
 			);
 			path = "mc2-DreamLog";
@@ -156,9 +158,10 @@
 			isa = PBXGroup;
 			children = (
 				784EB5D82A03467B0096D427 /* ImagePicker.swift */,
-				784EB5DA2A0346C70096D427 /* EditMenuView.swift */,
 				784EB5DC2A0346E20096D427 /* BgColorGeoView.swift */,
 				784EB5DE2A0346FA0096D427 /* MultiPreview.swift */,
+				784EB5DA2A0346C70096D427 /* EditMenuView.swift */,
+				784EB5E02A0370E80096D427 /* EditColorView.swift */,
 			);
 			path = Componets;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				784EB5C32A03453B0096D427 /* BindingExtension.swift in Sources */,
 				784EB5DF2A0346FA0096D427 /* MultiPreview.swift in Sources */,
 				784EB5C92A0345A20096D427 /* MainView.swift in Sources */,
+				784EB5E12A0370E80096D427 /* EditColorView.swift in Sources */,
 				784EB5D62A0346470096D427 /* TutorialWidgetView.swift in Sources */,
 				784EB5C62A0345630096D427 /* TutorialBoardElement.swift in Sources */,
 				784EB5C12A0342C90096D427 /* ViewExtension.swift in Sources */,

--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		166972642A015A4600702B59 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166972632A015A4600702B59 /* ContentView.swift */; };
 		166972662A015A4800702B59 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 166972652A015A4800702B59 /* Assets.xcassets */; };
 		166972692A015A4800702B59 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 166972682A015A4800702B59 /* Preview Assets.xcassets */; };
+		782E9AF12A0379CC0025FD48 /* BoardElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E9AF02A0379CC0025FD48 /* BoardElement.swift */; };
 		784EB5B92A03423B0096D427 /* ButtonBrownModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5B82A03423B0096D427 /* ButtonBrownModifier.swift */; };
 		784EB5BB2A0342670096D427 /* ButtonWhiteBoldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5BA2A0342670096D427 /* ButtonWhiteBoldModifier.swift */; };
 		784EB5BD2A0342800096D427 /* TextBrownModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5BC2A0342800096D427 /* TextBrownModifier.swift */; };
@@ -39,6 +40,7 @@
 		166972632A015A4600702B59 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		166972652A015A4800702B59 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		166972682A015A4800702B59 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		782E9AF02A0379CC0025FD48 /* BoardElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardElement.swift; sourceTree = "<group>"; };
 		784EB5B82A03423B0096D427 /* ButtonBrownModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonBrownModifier.swift; sourceTree = "<group>"; };
 		784EB5BA2A0342670096D427 /* ButtonWhiteBoldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonWhiteBoldModifier.swift; sourceTree = "<group>"; };
 		784EB5BC2A0342800096D427 /* TextBrownModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBrownModifier.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				784EB5C52A0345630096D427 /* TutorialBoardElement.swift */,
+				782E9AF02A0379CC0025FD48 /* BoardElement.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 				784EB5CB2A0345B90096D427 /* DreamBoardView.swift in Sources */,
 				784EB5BF2A0342990096D427 /* TextGrayModifier.swift in Sources */,
 				166972642A015A4600702B59 /* ContentView.swift in Sources */,
+				782E9AF12A0379CC0025FD48 /* BoardElement.swift in Sources */,
 				166972622A015A4600702B59 /* mc2_DreamLogApp.swift in Sources */,
 				784EB5C32A03453B0096D427 /* BindingExtension.swift in Sources */,
 				784EB5DF2A0346FA0096D427 /* MultiPreview.swift in Sources */,

--- a/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
@@ -23,5 +23,28 @@ extension View {
     func grayText(fontSize: CGFloat = 18) -> some View {
         modifier(TextGrayModifier(fontSize: fontSize))
     }
+    
+    
+    /// Text(String)를 image로 변환해준다. 이미 속성이 전부 적용된 텍스트뷰를 이미지로 바꾸는 형식이 아님
+    /// - Parameters:
+    ///   - text: 텍스트뷰에 들어가야할 텍스트
+    ///   - backgroundColor: 배경색, 기본은 투명색이다
+    ///   - textColor: 글자색, 기본은 검은색이다
+    /// - Returns: 속성이 적용된 텍스트가 여백없이 UIImage 형태로 반환
+    func textToImage(text: String, backgroundColor: UIColor = .clear, textColor: UIColor = .black) -> UIImage {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.backgroundColor = backgroundColor
+        label.textColor = textColor
+        label.text = text
+        label.sizeToFit() // Size the label to fit the text
+        
+        UIGraphicsBeginImageContextWithOptions(label.bounds.size, false, 0)
+        label.layer.render(in: UIGraphicsGetCurrentContext()!)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return image!
+    }
 }
 

--- a/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
@@ -33,10 +33,12 @@ extension View {
     /// - Returns: 속성이 적용된 텍스트가 여백없이 UIImage 형태로 반환
     func textToImage(text: String, backgroundColor: UIColor = .clear, textColor: UIColor = .black) -> UIImage {
         let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 100)
         label.textAlignment = .center
         label.backgroundColor = backgroundColor
         label.textColor = textColor
         label.text = text
+        
         label.sizeToFit() // Size the label to fit the text
         
         UIGraphicsBeginImageContextWithOptions(label.bounds.size, false, 0)

--- a/mc2-DreamLog/mc2-DreamLog/Model/BoardElement.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/BoardElement.swift
@@ -11,21 +11,20 @@ struct BoardElement: Identifiable, Hashable {
     
     let id = UUID()
     
-    // 위치 : offset 용
-    var x: CGFloat = 0
-    var y: CGFloat = 0
+    var offsetX: CGFloat = 0
+    var offsetY: CGFloat = 0
 
-    var angle = 0
+    var elementAngle = 0
     
-    var scale = 1
+    var elmentScale = 1
     
     var elementView: Image
     
-    init(x: CGFloat = 0, y: CGFloat = 0, angle: Int = 0, scale: Int = 1, elementView: Image) {
-        self.x = x
-        self.y = y
-        self.angle = angle
-        self.scale = scale
+    init(offsetX: CGFloat = 0, offsetY: CGFloat = 0, elementAngle: Int = 0, elmentScale: Int = 1, elementView: Image) {
+        self.offsetX = offsetX
+        self.offsetY = offsetY
+        self.elementAngle = elementAngle
+        self.elmentScale = elmentScale
         self.elementView = elementView
     }
     

--- a/mc2-DreamLog/mc2-DreamLog/Model/BoardElement.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/BoardElement.swift
@@ -1,0 +1,35 @@
+//
+//  BoardElement.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/04.
+//
+
+import SwiftUI
+
+struct BoardElement: Identifiable, Hashable {
+    
+    let id = UUID()
+    
+    // 위치 : offset 용
+    var x: CGFloat = 0
+    var y: CGFloat = 0
+
+    var angle = 0
+    
+    var scale = 1
+    
+    var elementView: Image
+    
+    init(x: CGFloat = 0, y: CGFloat = 0, angle: Int = 0, scale: Int = 1, elementView: Image) {
+        self.x = x
+        self.y = y
+        self.angle = angle
+        self.scale = scale
+        self.elementView = elementView
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
@@ -9,7 +9,5 @@ import SwiftUI
 
 class TutorialBoardElement : ObservableObject {
     
-    @Published var textArr: [String] = []
     @Published var viewArr: [BoardElement] = []
-    
 }

--- a/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 class TutorialBoardElement : ObservableObject {
     
-    @Published var imageArr: [UIImage] = []
     @Published var textArr: [String] = []
+    @Published var viewArr: [BoardElement] = []
+    
 }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditColorView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditColorView.swift
@@ -1,0 +1,71 @@
+//
+//  EditColorView.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/04.
+//
+
+import SwiftUI
+
+struct EditColorView: View {
+    
+    @State private var sliderValue = 3.0
+    @State var colorNum = 0
+    let colorArr: [Color] = [
+        .blue,
+        .purple,
+        .brown,
+        .cyan,
+        .green,
+        .indigo,
+        .mint,
+        .orange,
+        .pink,
+        .blue,
+        .purple,
+        .brown,
+        .cyan,
+        .green,
+        .indigo,
+        .mint,
+        .orange,
+        .pink
+    ]
+    
+    var body: some View {
+        VStack {
+            
+            ScrollView(.horizontal,showsIndicators: false) {
+                HStack {
+                    ForEach(0..<colorArr.count, id: \.self) { colorIndex in
+                        Circle()
+                            .frame(width: colorNum == colorIndex ? 30 : 20)
+                            .foregroundColor(colorArr[colorIndex])
+                            .onTapGesture {
+                                withAnimation(.easeInOut(duration: 0.36)) {
+                                    colorNum = colorIndex
+                                }
+                            }
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .frame(height: 80)
+            
+            HStack {
+                Circle().foregroundColor(.textGray).frame(width: 10)
+                Slider(value: $sliderValue, in: 1...30, step: 1)
+                    .padding(.horizontal, 20)
+                
+                Circle().foregroundColor(.textGray).frame(width: 30)
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+}
+
+struct EditColorView_Previews: PreviewProvider {
+    static var previews: some View {
+        EditColorView()
+    }
+}

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 struct EditMenuView: View {
     
     @State var showImagePicker = false
-    @State var image = UIImage()
+    @State var elementImage = UIImage()
     @EnvironmentObject var data: TutorialBoardElement
     
     @State var btnNames: [String] = [
@@ -35,7 +35,7 @@ struct EditMenuView: View {
                 if self.showImagePicker && !$0 {
                     print("log")
                     data.viewArr.append(
-                        .init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.image))
+                        .init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.elementImage))
                     )
                 }
                 self.showImagePicker = $0
@@ -65,7 +65,7 @@ struct EditMenuView: View {
             }
         }
         .sheet(isPresented: binding) {
-            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$elementImage)
         }
     }
 }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -15,31 +15,10 @@ import SwiftUI
 
 struct EditMenuView: View {
     
-    @State private var sliderValue = 3.0
-    @State var colorNum = 0
+    @State var showImagePicker = false
+    @State var image = UIImage()
     
-    let colorArr: [Color] = [
-        .blue,
-        .purple,
-        .brown,
-        .cyan,
-        .green,
-        .indigo,
-        .mint,
-        .orange,
-        .pink,
-        .blue,
-        .purple,
-        .brown,
-        .cyan,
-        .green,
-        .indigo,
-        .mint,
-        .orange,
-        .pink
-    ]
     @State var btnNames: [String] = [
-        "hand.draw",
         "character",
         "paintbrush.pointed",
         "photo",
@@ -50,43 +29,12 @@ struct EditMenuView: View {
     var body: some View {
         
         VStack{
-            // 색상 고르는 뷰 & 펜 두꺼움 고르는 슬라이더
-            // EditColorView
-            VStack {
-                
-                ScrollView(.horizontal,showsIndicators: false) {
-                    HStack {
-                        ForEach(0..<colorArr.count, id: \.self) { colorIndex in
-                            Circle()
-                                .frame(width: colorNum == colorIndex ? 40 : 30)
-                                .foregroundColor(colorArr[colorIndex])
-                                .onTapGesture {
-                                    withAnimation(.easeInOut(duration: 0.36)) {
-                                        colorNum = colorIndex
-                                    }
-                                }
-                        }
-                    }
-                }
-                .padding(.horizontal)
-                
-                HStack {
-                    Circle().foregroundColor(.textGray).frame(width: 10)
-                    Slider(value: $sliderValue, in: 1...30, step: 1)
-                        .padding(.horizontal, 20)
-                    
-                    Circle().foregroundColor(.textGray).frame(width: 30)
-                }
-                .padding(.horizontal, 20)
-            }
             
-            // 메인 편집 설정 창
-            // EditMenuView
             HStack {
                 Spacer()
                 ForEach(btnNames, id: \.self) { name in
                     Button {
-                        print("clicked")
+                        showImagePicker = true
                     } label: {
                         Image(systemName: name)
                             .foregroundColor(.secondary)
@@ -97,9 +45,12 @@ struct EditMenuView: View {
                     }
                 }
                 .padding(.bottom, 20)
-                //                .padding(.top, 80)
+                .padding(.top, 80)
                 Spacer()
             }
+        }
+        .sheet(isPresented: $showImagePicker) {
+            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
         }
     }
 }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -35,7 +35,7 @@ struct EditMenuView: View {
                 if self.showImagePicker && !$0 {
                     print("log")
                     data.viewArr.append(
-                        .init(x: Double.random(in: -100...100), y: Double.random(in: -100...100), elementView: Image(uiImage: self.image))
+                        .init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.image))
                     )
                 }
                 self.showImagePicker = $0

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -32,9 +32,13 @@ struct EditMenuView: View {
         let binding = Binding<Bool>(
             get: { self.showImagePicker },
             set: {
+                if self.showImagePicker && !$0 {
+                    print("log")
+                    data.viewArr.append(
+                        .init(x: Double.random(in: -100...100), y: Double.random(in: -100...100), elementView: Image(uiImage: self.image))
+                    )
+                }
                 self.showImagePicker = $0
-//                data.imageArr.append(self.image)
-                data.viewArr.append(.init(elementView: Image(uiImage: self.image)))
             }
         )
         

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -33,7 +33,8 @@ struct EditMenuView: View {
             get: { self.showImagePicker },
             set: {
                 self.showImagePicker = $0
-                data.imageArr.append(self.image)
+//                data.imageArr.append(self.image)
+                data.viewArr.append(.init(elementView: Image(uiImage: self.image)))
             }
         )
         
@@ -51,6 +52,7 @@ struct EditMenuView: View {
                             .background(.white)
                             .clipShape(Circle())
                             .shadow(radius: 2)
+                            
                     }
                 }
                 .padding(.bottom, 20)

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -17,6 +17,7 @@ struct EditMenuView: View {
     
     @State var showImagePicker = false
     @State var image = UIImage()
+    @EnvironmentObject var data: TutorialBoardElement
     
     @State var btnNames: [String] = [
         "character",
@@ -27,6 +28,14 @@ struct EditMenuView: View {
     ]
     
     var body: some View {
+        
+        let binding = Binding<Bool>(
+            get: { self.showImagePicker },
+            set: {
+                self.showImagePicker = $0
+                data.imageArr.append(self.image)
+            }
+        )
         
         VStack{
             
@@ -49,7 +58,7 @@ struct EditMenuView: View {
                 Spacer()
             }
         }
-        .sheet(isPresented: $showImagePicker) {
+        .sheet(isPresented: binding) {
             ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
         }
     }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/MultiPreview.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/MultiPreview.swift
@@ -20,16 +20,19 @@ struct MultiPreview<Content>: View where Content: View {
             content()
         }
         .previewDisplayName("iPhone SE (3rd generation)")
+        .environmentObject(TutorialBoardElement())
         NavigationStack {
             content()
         }
         .previewDevice("iPhone 14 Pro")
         .previewDisplayName("iPhone 14 Pro")
+        .environmentObject(TutorialBoardElement())
         NavigationStack {
             content()
         }
         .previewDevice("iPhone 13 mini")
         .previewDisplayName("iPhone 13 mini")
+        .environmentObject(TutorialBoardElement())
     }
 }
 

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct TutorialView: View {
     
     
-    @State var image = UIImage(named: "DashPlus")!
-    @State var text: String = ""
+    @State var tutorialImage = UIImage(named: "DashPlus")!
+    @State var tutorialText: String = ""
     
     @EnvironmentObject var data : TutorialBoardElement //
     
@@ -34,9 +34,9 @@ struct TutorialView: View {
     var body: some View {
         
         let binding = Binding<String>(
-            get: { self.text },
+            get: { self.tutorialText },
             set: {
-                self.text = $0
+                self.tutorialText = $0
                 self.textFieldChanged()
             }
         )
@@ -62,7 +62,7 @@ struct TutorialView: View {
                         .padding(.vertical, 18)
                     
                     if index < 2 {
-                        Image(uiImage: image)
+                        Image(uiImage: tutorialImage)
                             .resizable()
                             .scaledToFit()
                             .padding(.bottom, 22)
@@ -75,15 +75,15 @@ struct TutorialView: View {
                     NavigationLink(value: showEdit, label: {
                         Button {
                             
-                            if !image.isEqual(UIImage(named: "DashPlus")!) {
+                            if !tutorialImage.isEqual(UIImage(named: "DashPlus")!) {
                                 
-                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.image)))
-                                self.image = UIImage(named: "DashPlus")!
+                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.tutorialImage)))
+                                self.tutorialImage = UIImage(named: "DashPlus")!
                             }
                             
-                            if self.text != ""  {
-                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: textToImage(text: self.text))))
-                                text = ""
+                            if self.tutorialText != ""  {
+                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: textToImage(text: self.tutorialText))))
+                                tutorialText = ""
                             }
                             
                             if index == 2 {
@@ -109,10 +109,10 @@ struct TutorialView: View {
         }
         .navigationBarBackButtonHidden(true)
         .sheet(isPresented: $showSheet) {
-            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$tutorialImage)
         }
         .onAppear {
-            image = UIImage(named: "DashPlus")!
+            tutorialImage = UIImage(named: "DashPlus")!
             index = 0
             data.viewArr.removeAll()
         }
@@ -133,7 +133,7 @@ struct TutorialView_Previews: PreviewProvider {
 extension TutorialView {
     
     private func textFieldChanged() {
-        if text != "" || !image.isEqual(UIImage(named: "DashPlus")!) {
+        if tutorialText != "" || !tutorialImage.isEqual(UIImage(named: "DashPlus")!) {
             isActive = true
         } else {
             isActive = false

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -77,7 +77,7 @@ struct TutorialView: View {
                             
                             if !image.isEqual(UIImage(named: "DashPlus")!) {
                                 
-                                data.viewArr.append(BoardElement.init(x: Double.random(in: -100...100), y: Double.random(in: -100...100), elementView: Image(uiImage: self.image)))
+                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: self.image)))
                                 self.image = UIImage(named: "DashPlus")!
                             }
                             

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -82,7 +82,7 @@ struct TutorialView: View {
                             }
                             
                             if self.text != ""  {
-                                data.textArr.append(self.text)
+                                data.viewArr.append(BoardElement.init(offsetX: Double.random(in: -100...100), offsetY: Double.random(in: -100...100), elementView: Image(uiImage: textToImage(text: self.text))))
                                 text = ""
                             }
                             
@@ -114,7 +114,6 @@ struct TutorialView: View {
         .onAppear {
             image = UIImage(named: "DashPlus")!
             index = 0
-            data.textArr.removeAll()
             data.viewArr.removeAll()
         }
         .ignoresSafeArea(.keyboard)

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -76,7 +76,8 @@ struct TutorialView: View {
                         Button {
                             
                             if !image.isEqual(UIImage(named: "DashPlus")!) {
-                                data.imageArr.append(self.image)
+                                
+                                data.viewArr.append(BoardElement.init(x: Double.random(in: -100...100), y: Double.random(in: -100...100), elementView: Image(uiImage: self.image)))
                                 self.image = UIImage(named: "DashPlus")!
                             }
                             
@@ -114,7 +115,7 @@ struct TutorialView: View {
             image = UIImage(named: "DashPlus")!
             index = 0
             data.textArr.removeAll()
-            data.imageArr.removeAll()
+            data.viewArr.removeAll()
         }
         .ignoresSafeArea(.keyboard)
         

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
@@ -14,54 +14,51 @@ struct TutorialBoardView: View {
     @EnvironmentObject var data: TutorialBoardElement
     
     var body: some View {
-            BgColorGeoView { geo in
-                
-                let width = geo.size.width
-                //                let height = geo.size.height
-                VStack {
-                    // 편집될 뷰로 교체하기
-                    ZStack {
-                        Color.gray.opacity(0.1)
-                            .onAppear {
-                                print("전달된 값 출력")
-                                print("Image: \(data.imageArr)")
-                                print("Text: \(data.textArr)")
-                            }
+        BgColorGeoView { geo in
+            
+            let width = geo.size.width
+            //                let height = geo.size.height
+            VStack {
+                // 편집될 뷰로 교체하기
+                ZStack {
+                    Color.gray.opacity(0.1)
+                       
+                    
+                    ForEach(data.viewArr, id: \.self) { item in
                         
-                        ForEach(data.imageArr, id: \.self) { item in
-                            Image(uiImage: item)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 150)
-                                .offset(x: Double.random(in: -100...100), y: Double.random(in: -100...100))
-                        }
-                        
-                        ForEach(data.textArr, id: \.self) { item in
-                            Text(item)
-                                .offset(x: Double.random(in: -100...100), y: Double.random(in: -100...100))
-                        }
+                        item.elementView
+                            .resizable()
+                            .scaledToFit()
+                            .offset(x: item.x, y: item.y)
+                            .frame(width: 150)
                     }
-                    Spacer()
-                    EditMenuView()
-                    HStack {
-                        Button {
-                            showScroll.toggle()
-                        } label: {
-                            Text("샘플보기")
-                                .frame(width: abs(width - 40) / 2,height: 60)
-                                .whiteWithBorderButton()
-                        }
-                        NavigationLink {
-                            TutorialCalendarView()
-                        } label: {
-                            Text("완료")
-                                .frame(width: abs(width - 40) / 2,height: 60)
-                                .brownButton(isActive: true)
-                        }
+                    
+                    ForEach(data.textArr, id: \.self) { item in
+                        Text(item)
+                            .offset(x: Double.random(in: -100...100), y: Double.random(in: -100...100))
                     }
                 }
-                .navigationBarBackButtonHidden(true)
+                Spacer()
+                EditMenuView()
+                HStack {
+                    Button {
+                        showScroll.toggle()
+                    } label: {
+                        Text("샘플보기")
+                            .frame(width: abs(width - 40) / 2,height: 60)
+                            .whiteWithBorderButton()
+                    }
+                    NavigationLink {
+                        TutorialCalendarView()
+                    } label: {
+                        Text("완료")
+                            .frame(width: abs(width - 40) / 2,height: 60)
+                            .brownButton(isActive: true)
+                    }
+                }
             }
+            .navigationBarBackButtonHidden(true)
+        }
         .sheet(isPresented: $showScroll) {
             ScrollView {
                 VStack(alignment: .center) {

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
@@ -32,11 +32,6 @@ struct TutorialBoardView: View {
                             .offset(x: item.offsetX, y: item.offsetY)
                             .frame(width: 150)
                     }
-                    
-                    ForEach(data.textArr, id: \.self) { item in
-                        Text(item)
-                            .offset(x: Double.random(in: -100...100), y: Double.random(in: -100...100))
-                    }
                 }
                 Spacer()
                 EditMenuView()

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TuturialBoardView.swift
@@ -29,7 +29,7 @@ struct TutorialBoardView: View {
                         item.elementView
                             .resizable()
                             .scaledToFit()
-                            .offset(x: item.x, y: item.y)
+                            .offset(x: item.offsetX, y: item.offsetY)
                             .frame(width: 150)
                     }
                     


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #19

# 작업한 내용
- [x] 이미지 버튼에 이미지 피커 올라오게 하는 기능 추가
- [x] 이미지 버튼으로 편집뷰에 이미지 넣기
- [x] 데이터 구조 수정 및 이미지 불러오는 방법 변경  
- [x] 이미지가 두장 불러와지는 버그 수정 
- [x] 텍스트를 이미지로 변환하는 코드 넣음
- [x] 튜토리얼에서 입력한 텍스트를 이미지로 변환해서 튜토리얼 편집 보드에 출력 기능 구현  


# 참고 사항
- 편집 메뉴 관련 상태 모델 만들기
- 버튼을 클릭하면 관련 설정 메뉴가 나오도록 구현
- 데이터 구조 관련 확인 요망 

기존 To do는 각자 편집 메뉴에서 화면 이동을 처리하여 각각 다른 화면에서 
기능을 구현하고 다시 합치는 방식으로 처리 할 것 이기에 위 작업은 보류했습니다.

# 관련 이슈
- resolved : #19 
