### PR TITLE
[Design] DreamLog#25 이미지 아래 응원문구가 뜨도록 수정

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
@@ -20,13 +20,25 @@ struct DreamBoardView: View {
             let width = geo.size.width
             let height = geo.size.height
             
+            
             VStack {
                 
-                Image("BoardDummy")
-                    .resizable()
-                    .scaledToFit()
-                    .padding(.bottom, 5)
-                    .padding(.horizontal, 10)
+                VStack(spacing: 0) {
+                    Image("BoardDummy")
+                        .resizable()
+//                        .scaledToFill()
+                        .frame(height: height - 200)
+                        .scaledToFill()
+                    Text(text)
+                        .grayText(fontSize: 19)
+                        .fontWeight(.semibold)
+                        .frame(width: abs(width - 20), height: 43, alignment: .center)
+                        .padding(.top, 10)
+                        .background(.white)
+                        
+                }
+                .frame(width: abs(width - 20))
+                .padding(.horizontal, 10)
                 
                 HStack {
                     Text("I")
@@ -69,10 +81,11 @@ struct DreamBoardView: View {
                             Alert(title: Text("\(cheerText)으로\n응원을 추가하시겠어요?"),
                                   message: Text("작성하신 응원은 위젯에 표시됩니다."),
                                   primaryButton: .default(Text("확인"), action: {
-                                      print("\(cheerText) saved")
-                                  }),
+                                print("\(cheerText) saved")
+                                text = cheerText
+                            }),
                                   secondaryButton: .cancel(Text("취소"), action: {
-                                  }))
+                            }))
                         })
                     }
                 }


### PR DESCRIPTION
현재 이미지 비율 높이 고정, 비율 수정과 보드 편집 뷰와의 크기 맞추는 작업이 필요

# PR 요약

작업한 브랜치
- Design/ #25

# 작업한 내용
- [x] 이미지 아래 응원문구가 뜨도록 수정
- [x] 이미지 높이를 고정하고 가로를 비율을 늘려서 레이아웃 맞춤 


# 참고 사항
- 비율 상제 수정과 보드 편집 뷰와의 크기 맞추는 작업이 필요 

# 관련 이슈
- resolved : #25
