### PR TITLE
[Feat] DreamLog #38 - EditMenuView 버튼 기능 분리

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		784EB5DD2A0346E20096D427 /* BgColorGeoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5DC2A0346E20096D427 /* BgColorGeoView.swift */; };
 		784EB5DF2A0346FA0096D427 /* MultiPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5DE2A0346FA0096D427 /* MultiPreview.swift */; };
 		784EB5E12A0370E80096D427 /* EditColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EB5E02A0370E80096D427 /* EditColorView.swift */; };
+		78B0160D2A08C2060069ED6F /* MenuButtonModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B0160C2A08C2060069ED6F /* MenuButtonModifier.swift */; };
 		78C24FD62A0242710070906B /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C24FD52A0242710070906B /* ColorExtension.swift */; };
 		83C60E1C2A03D51D00F8E76B /* EditDrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C60E1B2A03D51D00F8E76B /* EditDrawingView.swift */; };
 		83C60E2C2A05251500F8E76B /* EditDrawingMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C60E2B2A05251500F8E76B /* EditDrawingMenuView.swift */; };
@@ -70,6 +71,7 @@
 		784EB5DE2A0346FA0096D427 /* MultiPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiPreview.swift; sourceTree = "<group>"; };
 		784EB5E02A0370E80096D427 /* EditColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditColorView.swift; sourceTree = "<group>"; };
 		7891C6712A02802F006B5109 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		78B0160C2A08C2060069ED6F /* MenuButtonModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButtonModifier.swift; sourceTree = "<group>"; };
 		78C24FD52A0242710070906B /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		83C60E1B2A03D51D00F8E76B /* EditDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDrawingView.swift; sourceTree = "<group>"; };
 		83C60E2B2A05251500F8E76B /* EditDrawingMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDrawingMenuView.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				784EB5BA2A0342670096D427 /* ButtonWhiteBoldModifier.swift */,
 				784EB5BC2A0342800096D427 /* TextBrownModifier.swift */,
 				784EB5BE2A0342990096D427 /* TextGrayModifier.swift */,
+				78B0160C2A08C2060069ED6F /* MenuButtonModifier.swift */,
 			);
 			path = Modifier;
 			sourceTree = "<group>";
@@ -281,6 +284,7 @@
 				438E87862A0881CB00037E11 /* FixableImageView.swift in Sources */,
 				784EB5BB2A0342670096D427 /* ButtonWhiteBoldModifier.swift in Sources */,
 				784EB5DB2A0346C70096D427 /* EditMenuView.swift in Sources */,
+				78B0160D2A08C2060069ED6F /* MenuButtonModifier.swift in Sources */,
 				438E87882A0882AB00037E11 /* FocusUUID.swift in Sources */,
 				78C24FD62A0242710070906B /* ColorExtension.swift in Sources */,
 				9500AB9B2A07E2350034933C /* TutorialTextEditView.swift in Sources */,

--- a/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
@@ -24,6 +24,10 @@ extension View {
         modifier(TextGrayModifier(fontSize: fontSize))
     }
     
+    func menuButton() -> some View {
+        modifier(MenuButtonModifier())
+    }
+    
     
     /// Text(String)를 image로 변환해준다. 이미 속성이 전부 적용된 텍스트뷰를 이미지로 바꾸는 형식이 아님
     /// - Parameters:

--- a/mc2-DreamLog/mc2-DreamLog/Global/Modifier/MenuButtonModifier.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Modifier/MenuButtonModifier.swift
@@ -1,0 +1,20 @@
+//
+//  MenuButtonModifier.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/08.
+//
+
+import SwiftUI
+
+struct MenuButtonModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content
+            .foregroundColor(.secondary)
+            .padding()
+            .background(.white)
+            .clipShape(Circle())
+            .shadow(radius: 2)
+    }
+}

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -18,6 +18,7 @@ struct EditMenuView: View {
     @State var showImagePicker = false
     @State var elementImage = UIImage()
     @EnvironmentObject var data: TutorialBoardElement
+    @State var editState: EditState = .none
     
     @State var btnNames: [String] = [
         "character",
@@ -26,6 +27,10 @@ struct EditMenuView: View {
         "face.smiling",
         "rectangle"
     ]
+    
+    enum EditState {
+        case character, paintbrush, photo, face, rectangle, none
+    }
     
     var body: some View {
         
@@ -43,25 +48,33 @@ struct EditMenuView: View {
         )
         
         VStack{
-            
+            editview(editState: self.editState)
             HStack {
                 Spacer()
                 ForEach(btnNames, id: \.self) { name in
                     Button {
                         // 나중에 따로 기능 할당. 지금은 모든 버튼 앨범 띄우기로 되어있다.
-                        showImagePicker = true
+                        switch name {
+                        case "character":
+                            editState = .character
+                        case "paintbrush.pointed":
+                            editState = .paintbrush
+                        case "photo":
+                            showImagePicker = true
+                            editState = .photo
+                        case "face.smiling":
+                            editState = .face
+                        case "rectangle":
+                            editState = .rectangle
+                        default:
+                            editState = .none
+                        }
                     } label: {
                         Image(systemName: name)
-                            .foregroundColor(.secondary)
-                            .padding()
-                            .background(.white)
-                            .clipShape(Circle())
-                            .shadow(radius: 2)
-                            
+                            .menuButton()
                     }
                 }
                 .padding(.bottom, 20)
-                .padding(.top, 80)
                 Spacer()
             }
         }
@@ -75,6 +88,28 @@ struct EditBar_Previews: PreviewProvider {
     static var previews: some View {
         MultiPreview {
             EditMenuView()
+        }
+    }
+}
+
+extension EditMenuView {
+    
+    func editview(editState: EditState) -> some View {
+        return HStack {
+            switch editState {
+            case .character:
+                EmptyView()
+            case .paintbrush:
+                EmptyView()
+            case .photo:
+                EmptyView()
+            case .face:
+                Text("이모티콘 뷰가 들어갈 자리")
+            case .rectangle:
+                Text("위젯 관련 뷰가 들어갈 자리")
+            case .none:
+                EmptyView()
+            }
         }
     }
 }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #38 

# 작업한 내용
- [x] EditMenuView 버튼 기능 분리
- [x] Menu Button Custom Modifier 생성 


# 참고 사항
- EditMenuView의 버튼들에 각 액션을 할당 할 수 있도록 하였습니다.
- EditMenuView의 버튼의 설정자를 Cusom Modifier로 만들어 두었습니다.

# 관련 이슈
- resolved : #38
