### PR TITLE
[Feat] DreamLog #42 - EditMenu 버튼 기능 수정

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog/Global/Modifier/MenuButtonModifier.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Modifier/MenuButtonModifier.swift
@@ -11,7 +11,7 @@ struct MenuButtonModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .foregroundColor(.secondary)
+//            .foregroundColor(.secondary)
             .padding()
             .background(.white)
             .clipShape(Circle())

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -16,6 +16,9 @@ import SwiftUI
 struct EditMenuView: View {
     
     @State var showImagePicker = false
+    @State var showTextEditView = false
+    @State var showEditDrawingView = false
+    
     @State var elementImage = UIImage()
     @EnvironmentObject var data: TutorialBoardElement
     @State var editState: EditState = .none
@@ -26,6 +29,14 @@ struct EditMenuView: View {
         "photo",
         "face.smiling",
         "rectangle"
+    ]
+    
+    @State var btnDictionary: [String : EditState] = [
+        "character" : .character,
+        "paintbrush.pointed" : .paintbrush,
+        "photo" : .photo,
+        "face.smiling" : .face,
+        "rectangle" : .rectangle
     ]
     
     enum EditState {
@@ -51,35 +62,46 @@ struct EditMenuView: View {
             editview(editState: self.editState)
             HStack {
                 Spacer()
-                ForEach(btnNames, id: \.self) { name in
+                ForEach(0..<5, id: \.self) { index in
                     Button {
                         // 나중에 따로 기능 할당. 지금은 모든 버튼 앨범 띄우기로 되어있다.
-                        switch name {
-                        case "character":
-                            editState = .character
-                        case "paintbrush.pointed":
-                            editState = .paintbrush
-                        case "photo":
+                        switch index {
+                        case 0:
+                            editState = btnDictionary[btnNames[index]]!
+                            showTextEditView = true
+                        case 1:
+                            editState = btnDictionary[btnNames[index]]!
+                            showEditDrawingView = true
+                        case 2:
+                            editState = btnDictionary[btnNames[index]]!
                             showImagePicker = true
-                            editState = .photo
-                        case "face.smiling":
-                            editState = .face
-                        case "rectangle":
-                            editState = .rectangle
+                        case 3:
+                            editState = btnDictionary[btnNames[index]]!
+                        case 4:
+                            editState = btnDictionary[btnNames[index]]!
                         default:
-                            editState = .none
+                            editState = btnDictionary[btnNames[index]]!
                         }
+                        
+                        
                     } label: {
-                        Image(systemName: name)
+                        Image(systemName: btnNames[index])
                             .menuButton()
+                            .foregroundColor(editState == btnDictionary[btnNames[index]]! ? .textBrown : .textGray)
                     }
                 }
                 .padding(.bottom, 20)
                 Spacer()
             }
         }
-        .sheet(isPresented: binding) {
+        .sheet(isPresented: binding,onDismiss: stateNone) {
             ImagePicker(sourceType: .photoLibrary, selectedImage: self.$elementImage)
+        }
+        .fullScreenCover(isPresented: $showTextEditView, onDismiss: stateNone) {
+            Text("showTextEdit")
+        }
+        .fullScreenCover(isPresented: $showEditDrawingView, onDismiss: stateNone) {
+            Text("showEditDrawing")
         }
     }
 }
@@ -111,5 +133,11 @@ extension EditMenuView {
                 EmptyView()
             }
         }
+    }
+}
+
+extension EditMenuView {
+    func stateNone() {
+        editState = .none
     }
 }


### PR DESCRIPTION
버튼 누를시 선택한 버튼 색상 보이기 && 화면이동 기능 할당할 수 있게 변경

# PR 요약

작업한 브랜치
- feature/ #42

# 작업한 내용
- [x] 버튼 누를시 선택한 버튼 색상 보이기 && 화면이동 기능 할당할 수 있게 변경


# 참고 사항
- 아직 실제로 화면이동 기능이 달려있지는 않음

# 관련 이슈
- resolved : #42
