### PR TITLE
[Fix] DreamLog#59 - 캔버스에 이미지 추가 시에 사이즈 조절 오류 해결

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -51,7 +51,7 @@ struct EditMenuView: View {
                 if self.showImagePicker && !$0 {
                     
                     data.viewArr.append(
-                        .init(imagePosition: CGPoint(x:0, y:0), imageWidth: 200, imageHeight: (elementImage.size.height / elementImage.size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
+                        .init(imagePosition: CGPoint(x:0, y:0), imageWidth: (elementImage.size.width > elementImage.size.height) ?  200 : (elementImage.size.width / elementImage.size.height * 200), imageHeight: (elementImage.size.width > elementImage.size.height) ? (elementImage.size.height / elementImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
                     )
                 }
                 self.showImagePicker = $0

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EmojiPicker.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EmojiPicker.swift
@@ -37,7 +37,7 @@ struct EmojiPicker: View {
                             guard let image = UIImage(named: emoji) else {
                                 return
                             }
-                            data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: 200, imageHeight: (image.size.height / image.size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: image)))
+                            data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: (image.size.width > image.size.height) ?  200 : (image.size.width / image.size.height * 200), imageHeight: (image.size.width > image.size.height) ? (image.size.height / image.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: image)))
                         }
                 }
             }

--- a/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
@@ -46,7 +46,7 @@ struct EditDrawingView: View {
                     Button{
                         // save drawing
                         let capturedImage = DrawingView(canvas: $canvas, isDraw: $isDraw, type: $type, color: $colorArr[colorNum], width: $sliderValue).captureImage()
-                        data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: 200, imageHeight: (capturedImage.size.height / capturedImage.size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: capturedImage)))
+                        data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: (capturedImage.size.width > capturedImage.size.height) ?  200 : (capturedImage.size.width / capturedImage.size.height * 200), imageHeight: (capturedImage.size.width > capturedImage.size.height) ? (capturedImage.size.height / capturedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: capturedImage)))
                         dismiss()
                         
                     }label: {

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialTextEditView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialTextEditView.swift
@@ -68,7 +68,7 @@ struct TutorialTextEditView: View {
                                         return
                                     }
                                     /// BoardEditView로 renderImage 전달
-                                    data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: 200, imageHeight: (generatedImage.size.height / generatedImage.size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: generatedImage)))
+                                    data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:0, y:0), imageWidth: (generatedImage.size.width > generatedImage.size.height) ?  200 : (generatedImage.size.width / generatedImage.size.height * 200), imageHeight: (generatedImage.size.width > generatedImage.size.height) ? (generatedImage.size.height / generatedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: generatedImage)))
                                     /// 보드 뷰로 이동
                                     dismiss()
                                 }

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -77,12 +77,12 @@ struct TutorialView: View {
                             
                             if !tutorialImage.isEqual(UIImage(named: "DashPlus")!) {
                                 
-                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: -150...150), y:Double.random(in: -150...150)), imageWidth: 200, imageHeight: (tutorialImage.size.height / tutorialImage.size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: tutorialImage)))
+                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: -150...150), y:Double.random(in: -150...150)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: tutorialImage)))
                                 self.tutorialImage = UIImage(named: "DashPlus")!
                             }
                             
                             if self.tutorialText != ""  {
-                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: -150...150), y:Double.random(in: -150...150)), imageWidth: 200, imageHeight: (textToImage(text: self.tutorialText).size.height / textToImage(text: self.tutorialText).size.width * 200), angle: .degrees(0), angleSum: 0, picture: Image(uiImage: textToImage(text: self.tutorialText))))
+                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: -150...150), y:Double.random(in: -150...150)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: textToImage(text: self.tutorialText))))
                                 tutorialText = ""
                             }
                             


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/#59 - 캔버스에 이미지 추가 시에 사이즈 조절 오류 해결

# 작업한 내용
- 캔버스에 텍스트, 그림, 이미지 추가 시에 가로 세로 중에서 긴 쪽을 기준으로 비율을 맞춰서 이미지 사이즈 조절


# 참고 사항
-

# 관련 이슈
- resolved : #이슈번호
