### PR TITLE
[Feat] DreamLog#71 - EditDrawingView에 그림 전체 삭제버튼, Undo 버튼, Redo 버튼 구현

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
@@ -95,6 +95,47 @@ struct EditDrawingView: View {
                     }
                     .padding(.bottom, 20)
                     Spacer()
+                    
+                    // remove All
+                    Button {
+                        canvas.drawing.strokes.removeAll()
+                    } label: {
+                        Image(systemName: "eraser")
+                            .foregroundColor(isDraw ? .secondary : .textGreen)
+                            .padding()
+                            .background(.white)
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.bottom, 20)
+                    
+                    // Undo
+                    Button {
+                        var undoManager = canvas.undoManager
+                        undoManager?.undo()
+                    } label: {
+                        Image(systemName: "eraser")
+                            .foregroundColor(isDraw ? .secondary : .textGreen)
+                            .padding()
+                            .background(.white)
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.bottom, 20)
+                    
+                    // Redo
+                    Button {
+                        var undoManager = canvas.undoManager
+                        undoManager?.redo()
+                    } label: {
+                        Image(systemName: "eraser")
+                            .foregroundColor(isDraw ? .secondary : .textGreen)
+                            .padding()
+                            .background(.white)
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.bottom, 20)
                 }
             }
         }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/# 71 - EditDrawingView에 그림 전체 삭제버튼, Undo 버튼, Redo 버튼 구현

# 작업한 내용
- EditDrawingView에 그림 전체 삭제버튼, Undo 버튼, Redo 버튼 구현


# 참고 사항
-

# 관련 이슈
- resolved : #이슈번호
