### PR TITLE
[Fix] DreamLog#79 - EditMenuView에서 사진 선택 안했을때도 BoardElement가 추가되는 오류 수정

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -52,9 +52,12 @@ struct EditMenuView: View {
             set: {
                 if self.showImagePicker && !$0 {
                     
-                    data.viewArr.append(
-                        .init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (elementImage.size.width > elementImage.size.height) ?  200 : (elementImage.size.width / elementImage.size.height * 200), imageHeight: (elementImage.size.width > elementImage.size.height) ? (elementImage.size.height / elementImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
-                    )
+                    if elementImage.size.width != 0 {
+                        data.viewArr.append(
+                            .init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (elementImage.size.width > elementImage.size.height) ?  200 : (elementImage.size.width / elementImage.size.height * 200), imageHeight: (elementImage.size.width > elementImage.size.height) ? (elementImage.size.height / elementImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
+                        )
+                    }
+                    
                 }
                 self.showImagePicker = $0
             }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/FixableImageView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/FixableImageView.swift
@@ -81,7 +81,7 @@ struct FixableImageView: View {
     var resizeAndRotateDrag: some Gesture {
         DragGesture()
             .onChanged { gesture in
-                
+                print(environmentElementList.viewArr.count)
                 var centerToNewPositionDistance = sqrt(pow(gesture.location.x - thisElement.imagePosition.x, 2) + pow(gesture.location.y - thisElement.imagePosition.y, 2))
                 var imageDiagonal = sqrt(pow(thisElement.imageWidth,2) + pow(thisElement.imageHeight,2))
                 
@@ -98,7 +98,6 @@ struct FixableImageView: View {
                 let newAngle = atan2(gesture.location.y - thisElement.imagePosition.y, gesture.location.x - thisElement.imagePosition.x)
                 
                 thisElement.angleSum += (-(originalAngle - newAngle) * 180 / CGFloat.pi)
-                print(thisElement.angleSum)
                 thisElement.angle = .degrees(thisElement.angleSum)
                 
                 


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/#79

# 작업한 내용
- EditMenuView에서 사진 선택 안했을때도 BoardElement가 추가되는 오류 수정


# 참고 사항
-

# 관련 이슈
- resolved : #이슈번호
