### PR TITLE
[Feat] DreamLog#80 - 드림보드 이미지 캡쳐 및 사이즈 조절

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		957041532A0C72A3000633CD /* Pilseung Gothic Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 957041512A0C72A3000633CD /* Pilseung Gothic Regular.otf */; };
 		957041672A0C777C000633CD /* GabiaHeuldot.otf in Resources */ = {isa = PBXBuildFile; fileRef = 957041652A0C777C000633CD /* GabiaHeuldot.otf */; };
 		957041682A0C777C000633CD /* The Jamsil OTF 4 Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 957041662A0C777C000633CD /* The Jamsil OTF 4 Medium.otf */; };
+		9570416C2A0C856D000633CD /* Tab1Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9570416B2A0C856D000633CD /* Tab1Model.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +99,7 @@
 		957041512A0C72A3000633CD /* Pilseung Gothic Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pilseung Gothic Regular.otf"; sourceTree = "<group>"; };
 		957041652A0C777C000633CD /* GabiaHeuldot.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GabiaHeuldot.otf; sourceTree = "<group>"; };
 		957041662A0C777C000633CD /* The Jamsil OTF 4 Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "The Jamsil OTF 4 Medium.otf"; sourceTree = "<group>"; };
+		9570416B2A0C856D000633CD /* Tab1Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab1Model.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +173,7 @@
 				438E87872A0882AB00037E11 /* FocusUUID.swift */,
 				9500AB9C2A09E8620034933C /* ColorPreset.swift */,
 				781EC7C12A0B3C7B00C47893 /* TransferableUIImage.swift */,
+				9570416B2A0C856D000633CD /* Tab1Model.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				784EB5CB2A0345B90096D427 /* DreamBoardView.swift in Sources */,
 				9570414E2A0C7150000633CD /* FontExtension.swift in Sources */,
 				784EB5BF2A0342990096D427 /* TextGrayModifier.swift in Sources */,
+				9570416C2A0C856D000633CD /* Tab1Model.swift in Sources */,
 				781EC7C22A0B3C7B00C47893 /* TransferableUIImage.swift in Sources */,
 				166972642A015A4600702B59 /* ContentView.swift in Sources */,
 				9500AB9F2A09F6800034933C /* EmojiPicker.swift in Sources */,

--- a/mc2-DreamLog/mc2-DreamLog/Model/Tab1Model.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/Tab1Model.swift
@@ -1,0 +1,16 @@
+//
+//  Tab1Model.swift
+//  mc2-DreamLog
+//
+//  Created by Seungui Moon on 2023/05/11.
+//
+
+import SwiftUI
+
+/// Tab1에서 사용되는 데이터를 위한 Model입니다.
+/// 메인이미지, Date값들을 저장합니다.
+
+class Tab1Model {
+    static let instance = Tab1Model()
+    var image: UIImage?
+}

--- a/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
@@ -13,9 +13,12 @@ struct DreamBoardView: View {
     @State private var showingAlert: Bool = false
     @State private var confirmAlert: Bool = false
     @StateObject var cheerModel = dataModel()
-    @State private var boardImage: UIImage = UIImage(named: "BoardDummy")!
+//    @State private var boardImage: UIImage = !
+    @State private var boardImage: UIImage = Tab1Model.instance.image ?? UIImage(named: "BoardDummy")!
     
-    var photo: TransferableUIImage = .init(uiimage: UIImage(named: "BoardDummy")!, caption: "드림보드를 공유해보세요🚀")
+    var photo: TransferableUIImage {
+        return .init(uiimage: boardImage, caption: "드림보드를 공유해보세요🚀")
+    }
     
     var body: some View {
         BgColorGeoView { geo in
@@ -29,9 +32,7 @@ struct DreamBoardView: View {
                 VStack(spacing: 0) {
                     
                     Image(uiImage: boardImage)
-                        .resizable()
-                        .frame(height: height - 200)
-                        .scaledToFill()
+                        
                     
                     Text(text)
                         .grayText(fontSize: 19)
@@ -39,10 +40,9 @@ struct DreamBoardView: View {
                         .frame(width: abs(width - 20), height: 43, alignment: .center)
                         .padding(.top, 10)
                         .background(.white)
-                    
+                        .frame(width: abs(width - 20))
                 }
-                .frame(width: abs(width - 20))
-                .padding(.horizontal, 10)
+                
                 
                 HStack {
                     Text("I")

--- a/mc2-DreamLog/mc2-DreamLog/View/MainView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/MainView.swift
@@ -39,17 +39,17 @@ struct MainView: View {
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            if selection == 0 {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        print("+ clicked")
-                    } label: {
-                        Image(systemName: "plus")
-                            .foregroundColor(.textGreen)
-                            .font(.system(size: 22))
-                    }
-                }
-            }
+//            if selection == 0 {
+//                ToolbarItem(placement: .navigationBarTrailing) {
+//                    Button {
+//                        print("+ clicked")
+//                    } label: {
+//                        Image(systemName: "plus")
+//                            .foregroundColor(.textGreen)
+//                            .font(.system(size: 22))
+//                    }
+//                }
+//            }
         }
         
     }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #80 

# 작업한 내용
- 편집뷰에서 제작한 드림보드 이미지 변환
- 변환한 이미지 Tab1으로 전달


# 참고 사항
- Tab1Model 임시로 제작
- 추후 DreamBoardView 로드시 CoreData에서 이미지 불러오는 기능 필요

# 관련 이슈
- resolved : #80 
