### PR TITLE
[Fix] DreamLog#72 - 편집뷰에서 사진, 이모지, 텍스트, 그림 불러올때 기본 위치 설정

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -687,12 +687,12 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UG6UT639QH;
+				DEVELOPMENT_TEAM = JMM62MZQM5;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DreamBoardWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DreamBoardWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -715,12 +715,12 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UG6UT639QH;
+				DEVELOPMENT_TEAM = JMM62MZQM5;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DreamBoardWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DreamBoardWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/TutorialBoardElement.swift
@@ -10,7 +10,8 @@ import SwiftUI
 class TutorialBoardElement : ObservableObject {
     
     @Published var viewArr: [BoardElement] = []
-    
+    var TutorialBoardWidthCenter: CGFloat = 0
+    var TutorialBoardHeightCenter: CGFloat = 0
     
     func findOne(one: UUID) -> BoardElement {
         for index in 0...viewArr.count-1 {

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EditMenuView.swift
@@ -55,7 +55,7 @@ struct EditMenuView: View {
                     
                     if elementImage.size.width != 0 {
                         data.viewArr.append(
-                            .init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (elementImage.size.width > elementImage.size.height) ?  200 : (elementImage.size.width / elementImage.size.height * 200), imageHeight: (elementImage.size.width > elementImage.size.height) ? (elementImage.size.height / elementImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
+                            .init(imagePosition: CGPoint(x:data.TutorialBoardWidthCenter , y: data.TutorialBoardHeightCenter), imageWidth: (elementImage.size.width > elementImage.size.height) ?  200 : (elementImage.size.width / elementImage.size.height * 200), imageHeight: (elementImage.size.width > elementImage.size.height) ? (elementImage.size.height / elementImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: elementImage))
                         )
                         FUUID.focusUUID = data.viewArr.last!.id
                     }

--- a/mc2-DreamLog/mc2-DreamLog/View/Componets/EmojiPicker.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Componets/EmojiPicker.swift
@@ -38,7 +38,7 @@ struct EmojiPicker: View {
                             guard let image = UIImage(named: emoji) else {
                                 return
                             }
-                            data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (image.size.width > image.size.height) ?  200 : (image.size.width / image.size.height * 200), imageHeight: (image.size.width > image.size.height) ? (image.size.height / image.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: image)))
+                            data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:data.TutorialBoardWidthCenter , y: data.TutorialBoardHeightCenter), imageWidth: (image.size.width > image.size.height) ?  200 : (image.size.width / image.size.height * 200), imageHeight: (image.size.width > image.size.height) ? (image.size.height / image.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: image)))
                             FUUID.focusUUID = data.viewArr.last!.id
                         }
                 }

--- a/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/EditDrawingView.swift
@@ -54,7 +54,7 @@ struct EditDrawingView: View {
                     Button{
                         // save drawing
                         let capturedImage = DrawingView(canvas: $canvas, isDraw: $isDraw, type: $type, color: $colorArr[colorNum], width: $sliderValue).captureImage()
-                        data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (capturedImage.size.width > capturedImage.size.height) ?  200 : (capturedImage.size.width / capturedImage.size.height * 200), imageHeight: (capturedImage.size.width > capturedImage.size.height) ? (capturedImage.size.height / capturedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: capturedImage)))
+                        data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:data.TutorialBoardWidthCenter , y: data.TutorialBoardHeightCenter), imageWidth: (capturedImage.size.width > capturedImage.size.height) ?  200 : (capturedImage.size.width / capturedImage.size.height * 200), imageHeight: (capturedImage.size.width > capturedImage.size.height) ? (capturedImage.size.height / capturedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: capturedImage)))
                         FUUID.focusUUID = data.viewArr.last!.id
                         dismiss()
                         

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialTextEditView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialTextEditView.swift
@@ -75,7 +75,7 @@ struct TutorialTextEditView: View {
                                         return
                                     }
                                     /// BoardEditView로 renderImage 전달
-                                    data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:UIScreen.main.bounds.width / 2, y:UIScreen.main.bounds.height / 2), imageWidth: (generatedImage.size.width > generatedImage.size.height) ?  200 : (generatedImage.size.width / generatedImage.size.height * 200), imageHeight: (generatedImage.size.width > generatedImage.size.height) ? (generatedImage.size.height / generatedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: generatedImage)))
+                                    data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:data.TutorialBoardWidthCenter , y: data.TutorialBoardHeightCenter), imageWidth: (generatedImage.size.width > generatedImage.size.height) ?  200 : (generatedImage.size.width / generatedImage.size.height * 200), imageHeight: (generatedImage.size.width > generatedImage.size.height) ? (generatedImage.size.height / generatedImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: generatedImage)))
                                     /// 보드 뷰로 이동
                                     FUUID.focusUUID = data.viewArr.last!.id
                                     dismiss()

--- a/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/Tutorial/TutorialView.swift
@@ -75,14 +75,17 @@ struct TutorialView: View {
                     NavigationLink(value: showEdit, label: {
                         Button {
                             
+                            data.TutorialBoardWidthCenter = geo.size.width / 2
+                            data.TutorialBoardHeightCenter = (geo.size.height - 250) / 2
+                            
                             if !tutorialImage.isEqual(UIImage(named: "DashPlus")!) {
                                 
-                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: 0...300), y:Double.random(in: 0...300)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: tutorialImage)))
+                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: data.TutorialBoardWidthCenter-100...data.TutorialBoardWidthCenter+100) , y: Double.random(in: data.TutorialBoardHeightCenter-100...data.TutorialBoardHeightCenter+100)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: tutorialImage)))
                                 self.tutorialImage = UIImage(named: "DashPlus")!
                             }
                             
                             if self.tutorialText != ""  {
-                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: 0...300), y:Double.random(in: 0...300)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: textToImage(text: self.tutorialText))))
+                                data.viewArr.append(BoardElement.init(imagePosition: CGPoint(x:Double.random(in: data.TutorialBoardWidthCenter-100...data.TutorialBoardWidthCenter+100) , y: Double.random(in: data.TutorialBoardHeightCenter-100...data.TutorialBoardHeightCenter+100)), imageWidth: (tutorialImage.size.width > tutorialImage.size.height) ?  200 : (tutorialImage.size.width / tutorialImage.size.height * 200), imageHeight: (tutorialImage.size.width > tutorialImage.size.height) ? (tutorialImage.size.height / tutorialImage.size.width * 200) : 200, angle: .degrees(0), angleSum: 0, picture: Image(uiImage: textToImage(text: self.tutorialText))))
                                 tutorialText = ""
                             }
                             


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/#72

# 작업한 내용
- 편집뷰에서 사진, 이모지, 텍스트, 그림 불러올때 기본 위치 설정


# 참고 사항
-

# 관련 이슈
- resolved : #이슈번호
