### PR TITLE
[Feat] DreamLog #121 응원로그 저장방식 변경 & 메인뷰에 데이터 띄우기

### DIFF
--- a/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
+++ b/mc2-DreamLog/mc2-DreamLog.xcodeproj/project.pbxproj
@@ -52,6 +52,10 @@
 		78A28BBE2A0DB6310034B0A9 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A28BBD2A0DB6310034B0A9 /* UIViewExtension.swift */; };
 		78B0160D2A08C2060069ED6F /* MenuButtonModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B0160C2A08C2060069ED6F /* MenuButtonModifier.swift */; };
 		78C24FD62A0242710070906B /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C24FD52A0242710070906B /* ColorExtension.swift */; };
+		78D85B642A0F3EE100483D95 /* DreamLogTableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D85B632A0F3EE100483D95 /* DreamLogTableProtocol.swift */; };
+		78D85B662A0F3EF000483D95 /* CheerLogTableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D85B652A0F3EF000483D95 /* CheerLogTableProtocol.swift */; };
+		78D85B682A0F3FDD00483D95 /* DBHelperExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D85B672A0F3FDD00483D95 /* DBHelperExtension.swift */; };
+		78D85B6A2A0F44E100483D95 /* CheerLogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D85B692A0F44E100483D95 /* CheerLogModel.swift */; };
 		83C60E1C2A03D51D00F8E76B /* EditDrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C60E1B2A03D51D00F8E76B /* EditDrawingView.swift */; };
 		83C60E2C2A05251500F8E76B /* EditDrawingMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C60E2B2A05251500F8E76B /* EditDrawingMenuView.swift */; };
 		9500AB9B2A07E2350034933C /* TutorialTextEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9500AB9A2A07E2350034933C /* TutorialTextEditView.swift */; };
@@ -140,6 +144,10 @@
 		78A28BBD2A0DB6310034B0A9 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		78B0160C2A08C2060069ED6F /* MenuButtonModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButtonModifier.swift; sourceTree = "<group>"; };
 		78C24FD52A0242710070906B /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		78D85B632A0F3EE100483D95 /* DreamLogTableProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamLogTableProtocol.swift; sourceTree = "<group>"; };
+		78D85B652A0F3EF000483D95 /* CheerLogTableProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerLogTableProtocol.swift; sourceTree = "<group>"; };
+		78D85B672A0F3FDD00483D95 /* DBHelperExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBHelperExtension.swift; sourceTree = "<group>"; };
+		78D85B692A0F44E100483D95 /* CheerLogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerLogModel.swift; sourceTree = "<group>"; };
 		83C60E1B2A03D51D00F8E76B /* EditDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDrawingView.swift; sourceTree = "<group>"; };
 		83C60E2B2A05251500F8E76B /* EditDrawingMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDrawingMenuView.swift; sourceTree = "<group>"; };
 		9500AB9A2A07E2350034933C /* TutorialTextEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialTextEditView.swift; sourceTree = "<group>"; };
@@ -264,6 +272,7 @@
 				78A28BBB2A0D0E920034B0A9 /* DBHelper.swift */,
 				782DFF692A0DC0D500DB62FF /* ImageFileManager.swift */,
 				43CEE4632A0E0CA80077559E /* DreamLogModel.swift */,
+				78D85B692A0F44E100483D95 /* CheerLogModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -317,6 +326,7 @@
 		78C24FD32A0242540070906B /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				78D85B622A0F3E9000483D95 /* Protocol */,
 				9570414F2A0C7240000633CD /* Resources */,
 				784EB5B72A03421C0096D427 /* Modifier */,
 				78C24FD42A02425E0070906B /* Extension */,
@@ -332,8 +342,18 @@
 				784EB5C22A03453B0096D427 /* BindingExtension.swift */,
 				9570414D2A0C7150000633CD /* FontExtension.swift */,
 				78A28BBD2A0DB6310034B0A9 /* UIViewExtension.swift */,
+				78D85B672A0F3FDD00483D95 /* DBHelperExtension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		78D85B622A0F3E9000483D95 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				78D85B632A0F3EE100483D95 /* DreamLogTableProtocol.swift */,
+				78D85B652A0F3EF000483D95 /* CheerLogTableProtocol.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		9570414F2A0C7240000633CD /* Resources */ = {
@@ -474,6 +494,7 @@
 				78A28BBC2A0D0E920034B0A9 /* DBHelper.swift in Sources */,
 				78C24FD62A0242710070906B /* ColorExtension.swift in Sources */,
 				9500AB9B2A07E2350034933C /* TutorialTextEditView.swift in Sources */,
+				78D85B662A0F3EF000483D95 /* CheerLogTableProtocol.swift in Sources */,
 				83C60E2C2A05251500F8E76B /* EditDrawingMenuView.swift in Sources */,
 				784EB5D92A03467B0096D427 /* ImagePicker.swift in Sources */,
 				784EB5CE2A0345E60096D427 /* TutorialStartView.swift in Sources */,
@@ -493,12 +514,15 @@
 				9500AB9F2A09F6800034933C /* EmojiPicker.swift in Sources */,
 				782E9AF12A0379CC0025FD48 /* BoardElement.swift in Sources */,
 				166972622A015A4600702B59 /* mc2_DreamLogApp.swift in Sources */,
+				78D85B642A0F3EE100483D95 /* DreamLogTableProtocol.swift in Sources */,
 				784EB5C32A03453B0096D427 /* BindingExtension.swift in Sources */,
 				784EB5DF2A0346FA0096D427 /* MultiPreview.swift in Sources */,
+				78D85B682A0F3FDD00483D95 /* DBHelperExtension.swift in Sources */,
 				83C60E1C2A03D51D00F8E76B /* EditDrawingView.swift in Sources */,
 				784EB5C92A0345A20096D427 /* MainView.swift in Sources */,
 				784EB5E12A0370E80096D427 /* EditColorView.swift in Sources */,
 				784EB5D62A0346470096D427 /* TutorialWidgetView.swift in Sources */,
+				78D85B6A2A0F44E100483D95 /* CheerLogModel.swift in Sources */,
 				784EB5C62A0345630096D427 /* TutorialBoardElement.swift in Sources */,
 				784EB5C12A0342C90096D427 /* ViewExtension.swift in Sources */,
 				784EB5D42A03462F0096D427 /* TutorialCalendarView.swift in Sources */,

--- a/mc2-DreamLog/mc2-DreamLog/Global/Extension/DBHelperExtension.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Extension/DBHelperExtension.swift
@@ -1,0 +1,301 @@
+//
+//  DBHelperExtension.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/13.
+//
+
+import SwiftUI
+import SQLite3
+
+    extension DBHelper: DreamLogTableProtocol {
+        func createDreamLogTable() {
+            
+            let query = """
+        CREATE TABLE IF NOT EXISTS DreamLog (
+          `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+          `picture` CHAR(255) NOT NULL,
+          `time` timestamp NOT NULL default current_timestamp
+        ) ;
+        """
+            var statement: OpaquePointer? = nil
+            // prepare는 쿼리를 실행할 준비를 하는 단계
+            if sqlite3_prepare_v2(self.db, query, -1, &statement, nil) == SQLITE_OK {
+                // step은 쿼리를 실행하는 단계
+                if sqlite3_step(statement) == SQLITE_DONE {
+                    print("Creating table has been succesfully done. db : \(String(describing: self.db))")
+                } else {
+                    let errorMessage = String(cString: sqlite3_errmsg(self.db))
+                    print("\nsqlite3_prepare failure while createing table: \(errorMessage)")
+                }
+                sqlite3_finalize(statement)
+            }
+        }
+        func insertDreamLogData(img: UIImage) {
+            // id 는 Auto increment 속성을 갖고 있기에 값을 대입해 줄 필요는 없지만 쿼리문에는 있어야함
+            let insertQuery = """
+            insert into DreamLog (
+            `id`,
+            picture
+            ) values (?, ?);
+            """
+            
+            var statement: OpaquePointer? = nil
+            // prepare는 쿼리를 실행할 준비를 하는 단계
+            if sqlite3_prepare_v2(self.db, insertQuery, -1, &statement, nil) == SQLITE_OK {
+                
+                // 이미지 처리
+                do {
+                    // get the documents directory url
+                    let documentsDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+                    
+                    UserDefaults.standard.set(documentsDirectory, forKey: "dataPath")
+                    
+                    print("documentsDirectory:", documentsDirectory.path)
+                    // choose a name for your image
+                    let fileName = "\(Date.now.description).jpg"
+                    //let image: Image = img
+                    let uiImage: UIImage = img
+                    
+                    // create the destination file url to save your image
+                    let fileURL = documentsDirectory.appendingPathComponent(fileName)
+                    // get your UIImage jpeg data representation and check if the destination file url already exists
+                    if let data = uiImage.jpegData(compressionQuality:  1),
+                       !FileManager.default.fileExists(atPath: fileURL.path) {
+                        // writes the image data to disk
+                        try data.write(to: fileURL)
+                        print("file saved")
+                        sqlite3_bind_text(statement, 2, fileName, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+                    }
+                } catch {
+                    print("error:", error)
+                }
+            }
+            else {
+                print("sqlite binding failure")
+            }
+            // step은 쿼리를 실행하는 단계
+            if sqlite3_step(statement) == SQLITE_DONE {
+                print("sqlite insertion success")
+            }
+            else {
+                print("sqlite step failure")
+            }
+        }
+        
+        func readDreamLogData() -> [DreamLogModel] {
+            
+            let query: String = "select * from DreamLog ORDER BY id DESC;"
+            var statement: OpaquePointer? = nil
+            
+            // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
+            var result: [DreamLogModel] = []
+            
+            if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
+                let errorMessage = String(cString: sqlite3_errmsg(db)!)
+                print("error while prepare: \(errorMessage)")
+                return result
+            }
+            while sqlite3_step(statement) == SQLITE_ROW {
+                
+                let id = sqlite3_column_int(statement, 0)
+                
+                let path = String(cString: sqlite3_column_text(statement, 1))
+                let time = String(cString: sqlite3_column_text(statement, 2))
+                
+                // 형변환을 해줘야함. Int의 경우 int32 형을 반환하기 때문
+                result.append(.init(id: Int(id), imagePath: path, time: time))
+                
+            }
+            sqlite3_finalize(statement)
+            print(result)
+            return result
+        }
+        
+        func readDreamLogDataOne() -> DreamLogModel {
+            
+            let query: String = "SELECT * FROM DreamLog ORDER BY id DESC LIMIT 1;"
+            var statement: OpaquePointer? = nil
+            
+            // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
+            var result: DreamLogModel = .init(id: -1, imagePath: "", time: "")
+            
+            if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
+                let errorMessage = String(cString: sqlite3_errmsg(db)!)
+                print("error while prepare: \(errorMessage)")
+                return result
+            }
+            while sqlite3_step(statement) == SQLITE_ROW {
+                
+                let id = sqlite3_column_int(statement, 0)
+                
+                let path = String(cString: sqlite3_column_text(statement, 1))
+                let time = String(cString: sqlite3_column_text(statement, 2))
+                
+                // 형변환을 해줘야함. Int의 경우 int32 형을 반환하기 때문
+                result = .init(id: Int(id), imagePath: path, time: time)
+            }
+            sqlite3_finalize(statement)
+            print(result)
+            return result
+        }
+        
+        
+        func deleteDreamLogData(id: Int) {
+            let queryString = "DELETE from DreamLog where id == \(id)"
+            var statement: OpaquePointer?
+            
+            if sqlite3_prepare(db, queryString, -1, &statement, nil) != SQLITE_OK {
+                onSQLErrorPrintErrorMessage(db)
+                return
+            }
+            // 쿼리 실행.
+            if sqlite3_step(statement) != SQLITE_DONE {
+                onSQLErrorPrintErrorMessage(db)
+                return
+            }
+            print("drop table has been successfully done")
+        }
+        
+        //id만 인자로 받아서 ID에 해당하는 레코드만 삭제하는 함수
+        func deleteImageByName(imgName: String) {
+            
+            let fileManager = FileManager.default // 파일 매니저 선언
+            let fileDirectoryPath =  fileManager.urls(for: .documentDirectory, in: .userDomainMask).first! // 애플리케이션 저장 폴더
+            
+            // [삭제를 수행할 파일 경로 지정]
+            let fileDeletePath = fileDirectoryPath.absoluteString + imgName
+            
+            do {
+                print("=====\(fileDeletePath)=====")
+                
+                try FileManager.default.removeItem(at: URL(string: fileDeletePath)!)
+            } catch let e {
+                print(e.localizedDescription)
+            }
+        }
+    }
+
+
+extension DBHelper: CheerLogTableProtocol {
+    
+    func createCheerLogTable() {
+        
+        let query = """
+        CREATE TABLE IF NOT EXISTS CheerLog (
+          `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+          `cheer` CHAR(255) NOT NULL,
+        `time` timestamp NOT NULL default current_timestamp
+        );
+        """
+        var statement: OpaquePointer? = nil
+        // prepare는 쿼리를 실행할 준비를 하는 단계
+        if sqlite3_prepare_v2(self.db, query, -1, &statement, nil) == SQLITE_OK {
+            // step은 쿼리를 실행하는 단계
+            if sqlite3_step(statement) == SQLITE_DONE {
+                print("Creating CheerLog table has been succesfully done. db : \(String(describing: self.db))")
+            } else {
+                let errorMessage = String(cString: sqlite3_errmsg(self.db))
+                print("\nsqlite3_prepare failure while createing table: \(errorMessage)")
+            }
+            sqlite3_finalize(statement)
+        }
+        
+        
+    }
+    
+    func insertCheerLogData(_ cheer: String) {
+        // id 는 Auto increment 속성을 갖고 있기에 값을 대입해 줄 필요는 없지만 쿼리문에는 있어야함
+        let insertQuery = """
+        insert into CheerLog (
+        `id`,
+        cheer
+        ) values (?, ?);
+        """
+        
+        var statement: OpaquePointer? = nil
+        // prepare는 쿼리를 실행할 준비를 하는 단계
+        if sqlite3_prepare_v2(self.db, insertQuery, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 2, cheer, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        else {
+            print("sqlite binding failure")
+        }
+        // step은 쿼리를 실행하는 단계
+        if sqlite3_step(statement) == SQLITE_DONE {
+            print("sqlite insertion success")
+        }
+        else {
+            print("sqlite step failure")
+        }
+    }
+    
+    func readCheerLogData() -> [CheerLogModel] {
+        let query: String = "SELECT * FROM CheerLog ORDER BY id DESC;"
+        var statement: OpaquePointer? = nil
+        
+        // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
+        var result: [CheerLogModel] = []
+        
+        if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
+            let errorMessage = String(cString: sqlite3_errmsg(db)!)
+            print("error while prepare: \(errorMessage)")
+            return result
+        }
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let id = sqlite3_column_int(statement, 0)
+            let cheer = String(cString: sqlite3_column_text(statement, 1))
+            let time = String(cString: sqlite3_column_text(statement, 2))
+            
+            result.append(.init(id: Int(id), cheer: cheer, time: time))
+        }
+        sqlite3_finalize(statement)
+        print("result - readCheerLogData: \(result)")
+        return result
+    }
+    
+    func readCheerLogDataOne() -> CheerLogModel {
+        let query: String = "SELECT * FROM CheerLog ORDER BY id DESC LIMIT 1;"
+        var statement: OpaquePointer? = nil
+        
+        // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
+        var result: CheerLogModel = .init(id: -1, cheer: "", time: "")
+        
+        if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
+            let errorMessage = String(cString: sqlite3_errmsg(db)!)
+            print("error while prepare: \(errorMessage)")
+            return result
+        }
+        while sqlite3_step(statement) == SQLITE_ROW {
+            
+            let id = sqlite3_column_int(statement, 0)
+            
+            let cheer = String(cString: sqlite3_column_text(statement, 1))
+            let time = String(cString: sqlite3_column_text(statement, 2))
+            
+            // 형변환을 해줘야함. Int의 경우 int32 형을 반환하기 때문
+            result = .init(id: Int(id), cheer: cheer, time: time)
+        }
+        sqlite3_finalize(statement)
+        print(result)
+        return result
+    }
+    
+    func deleteCheerLogData(id: Int) {
+        let queryString = "DELETE from CheerLog where id == \(id)"
+        var statement: OpaquePointer?
+        
+        if sqlite3_prepare(db, queryString, -1, &statement, nil) != SQLITE_OK {
+            onSQLErrorPrintErrorMessage(db)
+            return
+        }
+        // 쿼리 실행.
+        if sqlite3_step(statement) != SQLITE_DONE {
+            onSQLErrorPrintErrorMessage(db)
+            return
+        }
+        print("drop table has been successfully done")
+        
+    }
+}
+

--- a/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Extension/ViewExtension.swift
@@ -45,5 +45,23 @@ extension View {
         controller.view.removeFromSuperview()
         return image
     }
+    
+    func dateConverter(inputDateString: String) -> String {
+        
+        var dateString = inputDateString
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let date = dateFormatter.date(from: dateString)
+        
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateString = dateFormatter.string(from: date!)
+        
+        let calendar = Calendar.current
+        let updatedDate = calendar.date(byAdding: .hour, value: 9, to: date!)
+        
+        let updatedDateString = dateFormatter.string(from: updatedDate!)
+        
+        return updatedDateString
+    }
 }
 

--- a/mc2-DreamLog/mc2-DreamLog/Global/Protocol/CheerLogTableProtocol.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Protocol/CheerLogTableProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  CheerLogTableProtocol.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/13.
+//
+
+import Foundation
+import SwiftUI
+
+protocol CheerLogTableProtocol {
+    
+    func createCheerLogTable()
+    func insertCheerLogData(_ cheer: String)
+    func readCheerLogData() -> [CheerLogModel]
+    func readCheerLogDataOne() -> CheerLogModel
+    func deleteCheerLogData(id: Int)
+}

--- a/mc2-DreamLog/mc2-DreamLog/Global/Protocol/DreamLogTableProtocol.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Global/Protocol/DreamLogTableProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  DreamLogTableProtocol.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/13.
+//
+
+import SwiftUI
+
+protocol DreamLogTableProtocol {
+    
+    func createDreamLogTable()
+    func insertDreamLogData(img: UIImage)
+    func readDreamLogData() -> [DreamLogModel]
+    func readDreamLogDataOne() -> DreamLogModel
+    func deleteDreamLogData(id: Int)
+    func deleteImageByName(imgName: String)
+}

--- a/mc2-DreamLog/mc2-DreamLog/Model/CheerLogModel.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/CheerLogModel.swift
@@ -1,0 +1,37 @@
+//
+//  CheerLogModel.swift
+//  mc2-DreamLog
+//
+//  Created by ChoiYujin on 2023/05/13.
+//
+
+import Foundation
+
+class CheerLogModel: Hashable, Equatable {
+    
+    static func == (lhs: CheerLogModel, rhs: CheerLogModel) -> Bool {
+        lhs.id == rhs.id
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    static let shared = CheerLogModel()
+    
+    var id: Int
+    var cheer: String
+    var time: String
+    
+    private init() {
+        self.id = -1
+        self.cheer = ""
+        self.time = ""
+    }
+    
+    init(id: Int, cheer: String, time: String) {
+        self.id = id
+        self.cheer = cheer
+        self.time = time
+    }
+    
+}

--- a/mc2-DreamLog/mc2-DreamLog/Model/DBHelper.swift
+++ b/mc2-DreamLog/mc2-DreamLog/Model/DBHelper.swift
@@ -12,15 +12,11 @@ import SwiftUI
 class DBHelper {
     
     static let shared = DBHelper()
-    
-    var db : OpaquePointer?
-    private init() {}
-    
     let databaseName = "mydb.sqlite"
+    var db : OpaquePointer?
     
-    deinit {
-        sqlite3_close(db)
-    }
+    private init() {}
+    deinit { sqlite3_close(db) }
     
     func createDB() -> OpaquePointer? {
         var db: OpaquePointer? = nil
@@ -38,145 +34,8 @@ class DBHelper {
         }
         return nil
     }
-    
-    func createDreamLogTable() {
-        
-        let query = """
-    CREATE TABLE IF NOT EXISTS DreamLog (
-      `id` INTEGER PRIMARY KEY AUTOINCREMENT,
-      `picture` CHAR(255) NOT NULL,
-      `time` timestamp NOT NULL default current_timestamp
-    ) ;
-    """
-        
-        var statement: OpaquePointer? = nil
-        // prepare는 쿼리를 실행할 준비를 하는 단계
-        if sqlite3_prepare_v2(self.db, query, -1, &statement, nil) == SQLITE_OK {
-            // step은 쿼리를 실행하는 단계
-            if sqlite3_step(statement) == SQLITE_DONE {
-                print("Creating table has been succesfully done. db : \(String(describing: self.db))")
-            } else {
-                let errorMessage = String(cString: sqlite3_errmsg(self.db))
-                print("\nsqlite3_prepare failure while createing table: \(errorMessage)")
-            }
-            sqlite3_finalize(statement)
-        }
-    }
-    
-    func insertDreamLogData(img: UIImage) {
-        // id 는 Auto increment 속성을 갖고 있기에 값을 대입해 줄 필요는 없지만 쿼리문에는 있어야함
-        let insertQuery = """
-        insert into DreamLog (
-        `id`,
-        picture
-        ) values (?, ?);
-        """
-        
-        var statement: OpaquePointer? = nil
-        // prepare는 쿼리를 실행할 준비를 하는 단계
-        if sqlite3_prepare_v2(self.db, insertQuery, -1, &statement, nil) == SQLITE_OK {
-            
-            // 이미지 처리
-            do {
-                // get the documents directory url
-                let documentsDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-                
-                UserDefaults.standard.set(documentsDirectory, forKey: "dataPath")
-                
-                print("documentsDirectory:", documentsDirectory.path)
-                // choose a name for your image
-                let fileName = "\(Date.now.description).jpg"
-                //let image: Image = img
-                let uiImage: UIImage = img
-                
-                // create the destination file url to save your image
-                let fileURL = documentsDirectory.appendingPathComponent(fileName)
-                // get your UIImage jpeg data representation and check if the destination file url already exists
-                if let data = uiImage.jpegData(compressionQuality:  1),
-                   !FileManager.default.fileExists(atPath: fileURL.path) {
-                    // writes the image data to disk
-                    try data.write(to: fileURL)
-                    print("file saved")
-                    sqlite3_bind_text(statement, 2, fileName, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-                    
-                }
-            } catch {
-                print("error:", error)
-            }
-        }
-        else {
-            print("sqlite binding failure")
-        }
-        // step은 쿼리를 실행하는 단계
-        if sqlite3_step(statement) == SQLITE_DONE {
-            print("sqlite insertion success")
-        }
-        else {
-            print("sqlite step failure")
-        }
-    }
-    
-    func readDreamLogData() -> [DreamLogModel] {
-        
-        let query: String = "select * from DreamLog ORDER BY id DESC;"
-        var statement: OpaquePointer? = nil
-        
-        // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
-        var result: [DreamLogModel] = []
-        
-        if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
-            let errorMessage = String(cString: sqlite3_errmsg(db)!)
-            print("error while prepare: \(errorMessage)")
-            return result
-        }
-        while sqlite3_step(statement) == SQLITE_ROW {
-            
-            let id = sqlite3_column_int(statement, 0)
-            
-            let path = String(cString: sqlite3_column_text(statement, 1))
-            let time = String(cString: sqlite3_column_text(statement, 2))
-            
-            // 형변환을 해줘야함. Int의 경우 int32 형을 반환하기 때문
-            result.append(.init(id: Int(id), imagePath: path, time: time))
-            
-        }
-        sqlite3_finalize(statement)
-        print(result)
-        return result
-    }
-    
-    func readDreamLogDataOne() -> DreamLogModel {
-        
-        let query: String = "SELECT * FROM DreamLog ORDER BY id DESC LIMIT 1;"
-        var statement: OpaquePointer? = nil
-        
-        // 아래는 [MyModel]? 이 되면 값이 안 들어간다.
-        var result: DreamLogModel = .init(id: -1, imagePath: "", time: "")
-        
-        if sqlite3_prepare(self.db, query, -1, &statement, nil) != SQLITE_OK {
-            let errorMessage = String(cString: sqlite3_errmsg(db)!)
-            print("error while prepare: \(errorMessage)")
-            return result
-        }
-        while sqlite3_step(statement) == SQLITE_ROW {
-            
-            let id = sqlite3_column_int(statement, 0)
-            
-            let path = String(cString: sqlite3_column_text(statement, 1))
-            let time = String(cString: sqlite3_column_text(statement, 2))
-            
-            // 형변환을 해줘야함. Int의 경우 int32 형을 반환하기 때문
-            result = .init(id: Int(id), imagePath: path, time: time)
-            
-        }
-        sqlite3_finalize(statement)
-        print(result)
-        return result
-    }
-    
-    
-    // 값을 수정하기 전에 오류메시지가 계속 반복되니, 이를 해결하기 위한 함수
-    private func onSQLErrorPrintErrorMessage(_ db: OpaquePointer?) {
+
+    func onSQLErrorPrintErrorMessage(_ db: OpaquePointer?) {
         let errorMessage = String(cString: sqlite3_errmsg(db))
         print("Error preparing update: \(errorMessage)")
         return
@@ -201,46 +60,8 @@ class DBHelper {
         print("drop table has been successfully done")
         
     }
-    
-    func deleteDreamLogData(id: Int) {
-        let queryString = "DELETE from DreamLog where id == \(id)"
-        var statement: OpaquePointer?
-        
-        if sqlite3_prepare(db, queryString, -1, &statement, nil) != SQLITE_OK {
-            onSQLErrorPrintErrorMessage(db)
-            return
-        }
-        
-        // 쿼리 실행.
-        if sqlite3_step(statement) != SQLITE_DONE {
-            onSQLErrorPrintErrorMessage(db)
-            return
-        }
-        
-        print("drop table has been successfully done")
-        
-    }
-    
-    //id만 인자로 받아서 ID에 해당하는 레코드만 삭제하는 함수
-    func deleteImageByName(imgName: String) {
-        
-        let fileManager = FileManager.default // 파일 매니저 선언
-        let fileDirectoryPath =  fileManager.urls(for: .documentDirectory, in: .userDomainMask).first! // 애플리케이션 저장 폴더
-        
-        
-        // [삭제를 수행할 파일 경로 지정]
-        let fileDeletePath = fileDirectoryPath.absoluteString + imgName
-        
-        
-        do {
-            print("=====\(fileDeletePath)=====")
-            
-            try FileManager.default.removeItem(at: URL(string: fileDeletePath)!)
-        } catch let e {
-            print(e.localizedDescription)
-        }
-        
-    }
-    
 }
+
+
+
 

--- a/mc2-DreamLog/mc2-DreamLog/View/CheerLogView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/CheerLogView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CoreData
 
 struct CheerLogView: View {
     var body: some View {
@@ -31,107 +30,42 @@ struct CheerLogView: View {
 
 struct CheerList: View {
     
-    @StateObject var model = dataModel()
+    @State var cheerList: [CheerLogModel] = []
     
     var body: some View {
         VStack {
             
             List{
                 
-                ForEach(model.data, id: \.objectID) { obj in
-                    //Extracting data from obj
-                    let (cheer, writtenDate) = model.getValue(obj: obj)
-                    
+                ForEach(Array(cheerList.enumerated()), id: \.1) { (index, cheerData) in
                     VStack(alignment: .leading) {
-                        Text(cheer)
+                        Text(cheerData.cheer)
                             .multilineTextAlignment(.leading)
                             .padding(.bottom, 8)
-                        Text(writtenDate)
+                        
+                        Text(dateConverter(inputDateString: cheerData.time))
                             .font(.system(size: 14, weight: .regular))
                             .foregroundColor(.gray)
                     }
                 }
-                .onDelete(perform: model.deleteData(indexSet:))
+                .onDelete { indexSet in
+                    let indexes = indexSet.map { $0 }
+                    for index in indexes {
+                        let cheerData = cheerList[index]
+                        let i = cheerList.firstIndex(of: cheerData)!
+                        DBHelper.shared.deleteCheerLogData(id: cheerList[i].id)
+                        cheerList = DBHelper.shared.readCheerLogData()
+                    }
+                }
+                
             }
             .listStyle(InsetGroupedListStyle())
             .onAppear {
-                model.readData()
+                self.cheerList = DBHelper.shared.readCheerLogData()
             }
         }
     }
 }
-
-
-
-class dataModel: ObservableObject {
-    @Published var data: [NSManagedObject] = []
-    @Published var cheerText = ""
-    @Published var writtenDateText = ""
-    let context = persistentContainer.viewContext
-    
-    init() {
-        readData()
-    }
-    
-    func readData() {
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "CheerData")
-        
-        do {
-            let results = try context.fetch(request)
-            
-            self.data = results as! [NSManagedObject]
-        } catch {
-            print(error.localizedDescription)
-        }
-    }
-    
-    func writeData() {
-        let entity = NSEntityDescription.insertNewObject(forEntityName: "CheerData", into: context)
-        
-        entity.setValue(cheerText, forKey: "cheer")
-        entity.setValue(writtenDateText, forKey: "writtenDate")
-        
-        do {
-            try context.save()
-            self.data.append(entity)
-            
-            cheerText = ""
-            writtenDateText = ""
-            
-        } catch {
-            print(error.localizedDescription)
-        }
-    }
-    
-    func deleteData(indexSet: IndexSet) {
-        
-        for index in indexSet {
-            
-            do {
-                let obj = data[index]
-                context.delete(obj)
-            
-                try context.save()
-                
-                let index = data.firstIndex(of: obj)
-                data.remove(at: index!)
-            } catch {
-                print(error.localizedDescription)
-            }
-            
-        }
-    }
-    
-    func getValue(obj: NSManagedObject) -> (cheer: String, writtenDate: String) {
-        let cheer = obj.value(forKey: "cheer") as! String
-        let writtenDate = obj.value(forKey: "writtenDate") as! String
-        
-        return (cheer, writtenDate)
-    }
-}
-
-
-
 
 struct CheerLogView_Previews: PreviewProvider {
     static var previews: some View {

--- a/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/DreamBoardView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct DreamBoardView: View {
     @EnvironmentObject var data: TutorialBoardElement
     @State var isDone = false
-    @State var text = ""
+    @State var cheertext = ""
+    @State var alerttext = ""
     @State private var showingAlert: Bool = false
     @State private var confirmAlert: Bool = false
-    @StateObject var cheerModel = dataModel()
     @State private var boardImage: UIImage = Tab1Model.instance.image ?? UIImage(named: "BoardDummy")!
     
     @State private var showDDayCalendar = false
@@ -33,15 +33,13 @@ struct DreamBoardView: View {
             let width = geo.size.width
             let height = geo.size.height
             
-            
-            
             VStack {
                 
                 VStack(spacing: 0) {
                     
                     Image(uiImage: boardImage)
                     
-                    Text(text == "" ? "스스로를 위한 응원을 작성해보세요" : text)
+                    Text(cheertext == "" ? "스스로를 위한 응원을 작성해보세요" : cheertext)
                         .grayText(fontSize: 22)
                         .fontWeight(.semibold)
                         .frame(width: abs(width), height: 40, alignment: .center)
@@ -103,28 +101,30 @@ struct DreamBoardView: View {
                                 .foregroundColor(.textGreen)
                         }
                         .alert("나에게 주는 응원 한마디를\n작성해주세요", isPresented: $showingAlert, actions: {
-                            TextField("응원의 한 마디를 작성해보아요", text: $cheerModel.cheerText)
+                            TextField("응원의 한 마디를 작성해보아요", text: $alerttext)
                             
                             Button("완료", action: {
                                 confirmAlert = true
                             })
-                            Button("취소", role: .cancel, action: {})
+                            Button("취소", role: .cancel, action: {
+                                alerttext = ""
+                            })
                         })
                         .alert(isPresented: $confirmAlert, content: {
-                            Alert(title: Text("\(cheerModel.cheerText)으로\n응원을 추가하시겠어요?"),
+                            Alert(title: Text("\(alerttext)으로\n응원을 추가하시겠어요?"),
                                   message: Text("작성하신 응원은 위젯에 표시됩니다."),
                                   primaryButton: .default(Text("확인"), action: {
-                                text = cheerModel.cheerText
-                                cheerModel.writtenDateText = getCurrentDate()
-                                cheerModel.writeData() // 첫 번째 액션
-                                print(getCurrentDate())
-                                print($cheerModel.cheerText)
-                                
-                            }),
-                                  secondaryButton: .cancel(Text("취소"), action: {
-                                // 액션 없음
+                                // 데이터 처리
+                                DBHelper.shared.createCheerLogTable()
+                                DBHelper.shared.insertCheerLogData(alerttext)
+                                cheertext = DBHelper.shared.readCheerLogDataOne().cheer
+                            }), secondaryButton: .cancel(Text("취소"), action: {
+                                cheertext = DBHelper.shared.readCheerLogDataOne().cheer
+                                alerttext = ""
                             }))
+                            
                         })
+                        
                     }
                 }
                 .padding(.horizontal, 16)
@@ -136,14 +136,10 @@ struct DreamBoardView: View {
                 .shadow(color: Color.shadowGray, radius: 2, x: 0, y: 2)
             }
             .onAppear {
-                // 이것도 샘플 이미지로 바꿔주는 작업
-                self.boardImage = imageFileManager.getSavedImage(named: DBHelper.shared.readDreamLogDataOne().imagePath) ?? UIImage(named: "sticker_check")!
-            }
-            .onAppear {
                 getDDayDate()
+                self.boardImage = imageFileManager.getSavedImage(named: DBHelper.shared.readDreamLogDataOne().imagePath) ?? UIImage(named: "sticker_check")!
+                cheertext = DBHelper.shared.readCheerLogDataOne().cheer
             }
-            
-            
         }
     }
     
@@ -180,4 +176,6 @@ struct MainTab1View_Previews: PreviewProvider {
         }
     }
 }
+
+
 

--- a/mc2-DreamLog/mc2-DreamLog/View/DreamLogView.swift
+++ b/mc2-DreamLog/mc2-DreamLog/View/DreamLogView.swift
@@ -141,22 +141,4 @@ extension DreamLogView {
         let text = lastTimeString + " 부터 " + currnetTimeString + "까지의 드림보드"
         return text
     }
-    
-    func dateConverter(inputDateString: String) -> String {
-        
-        var dateString = inputDateString
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        let date = dateFormatter.date(from: dateString)
-        
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        dateString = dateFormatter.string(from: date!)
-        
-        let calendar = Calendar.current
-        let updatedDate = calendar.date(byAdding: .hour, value: 9, to: date!)
-        
-        let updatedDateString = dateFormatter.string(from: updatedDate!)
-        
-        return updatedDateString
-    }
 }

--- a/mc2-DreamLog/mc2-DreamLog/mc2_DreamLogApp.swift
+++ b/mc2-DreamLog/mc2-DreamLog/mc2_DreamLogApp.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CoreData
 
 @main
 struct mc2_DreamLogApp: App {
@@ -25,13 +24,16 @@ struct mc2_DreamLogApp: App {
                     MainView()
                         .onAppear {
                             sleep(2)
-                            _ = DBHelper.shared.createDB()
                         }
-                        .environment(\.managedObjectContext, persistentContainer.viewContext)
                 }
                 .environmentObject(TutorialBoardElement())
                 .environmentObject(FocusUUID())
                 .tint(.activeBrown)
+                .onAppear {
+                    _ = DBHelper.shared.createDB()
+                    DBHelper.shared.createDreamLogTable()
+                    DBHelper.shared.createCheerLogTable()
+                }
             } else {
                 TutorialStartView() // TutorialStartView
                     .environmentObject(TutorialBoardElement())
@@ -42,29 +44,6 @@ struct mc2_DreamLogApp: App {
                     }
                 
             }
-        }
-    }
-}
-
-var persistentContainer: NSPersistentContainer = {
-    
-    let container = NSPersistentContainer(name: "CoreData")
-    container.loadPersistentStores(completionHandler: { (storeDesc, error) in
-        if let error = error as NSError? {
-            fatalError("Unresolved error \(error), \(error.userInfo)")
-        }
-    })
-    return container
-}()
-
-func saveContext() {
-    let context = persistentContainer.viewContext
-    if context.hasChanges {
-        do {
-            try context.save()
-        } catch {
-            let nserror = error as NSError
-            fatalError("\(nserror), \(nserror.userInfo)")
         }
     }
 }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- Feat/#121

# 작업한 내용
- [x] 응원로그 저장방식 변경 coredata -> sqlite 
- [x] DBHelper 코드 extension & protocol로 분리
- [x] 응원 데이터 기능 완료 


# 참고 사항
- coredata 관련 코드는 삭제하였습니다.

# 관련 이슈
- resolved : #121
